### PR TITLE
Add support for Upstream-Version-{Prefix,Suffix}

### DIFF
--- a/publish_python/artifact/stdeb.py
+++ b/publish_python/artifact/stdeb.py
@@ -36,6 +36,9 @@ def create_deb(*, config):
                 key, value = env_var.split('=', 1)
                 add_env[key] = value
         debinc = config_parser.get(pkg.name, 'Debian-Version', fallback='1')
+        debver = config_parser.get(pkg.name, 'Upstream-Version-Prefix', fallback='')
+        debver += pkg.version
+        debver += config_parser.get(pkg.name, 'Upstream-Version-Suffix', fallback='')
 
         print(
             '$', *cmd,
@@ -49,10 +52,10 @@ def create_deb(*, config):
             os.unlink(tarball)
 
     return {
-        f'deb_dist/{source_pkg_name}_{pkg.version}.orig.tar.gz',
-        f'deb_dist/{source_pkg_name}_{pkg.version}-{debinc}.debian.tar.gz',
-        f'deb_dist/{source_pkg_name}_{pkg.version}-{debinc}.dsc',
-        f'deb_dist/{source_pkg_name}_{pkg.version}-{debinc}_all.deb'}
+        f'deb_dist/{source_pkg_name}_{debver}.orig.tar.gz',
+        f'deb_dist/{source_pkg_name}_{debver}-{debinc}.debian.tar.gz',
+        f'deb_dist/{source_pkg_name}_{debver}-{debinc}.dsc',
+        f'deb_dist/{source_pkg_name}_{debver}-{debinc}_all.deb'}
 
 
 def clean_deb():


### PR DESCRIPTION
These options change the name of the output artifacts, so we need to check for and use them appropriately.

https://github.com/astraw/stdeb/tree/master?tab=readme-ov-file#stdebcfg-configuration-file