### PR TITLE
Fix PyPI PEP 625 incompatibility

### DIFF
--- a/publish_python/artifact/wheel.py
+++ b/publish_python/artifact/wheel.py
@@ -15,11 +15,11 @@ def create_wheel(*, config):
     print('\n-- Building sdist and bdist_wheel artifacts of package '
           f"'{pkg.name}' {pkg.version} ...")
 
-    cmd = [sys.executable, 'setup.py', 'sdist', 'bdist_wheel']
+    cmd = [sys.executable, '-m', 'build']
     print('$', *cmd)
     subprocess.check_call(cmd)
 
-    tarball = f'dist/{pkg.name}-{pkg.version}.tar.gz'
+    tarball = f'dist/{pkg.name.replace("-", "_")}-{pkg.version}.tar.gz'
     assert os.path.exists(tarball), \
         f"Failed to generate source tarball '{tarball}'"
 


### PR DESCRIPTION
Uploading tarballs with `-` instead of `_` results in the following email sent to the uploader:

> In the future, PyPI will require all newly uploaded source
> distribution filenames to comply with PEP 625. Any source
> distributions already uploaded will remain in place as-is and do not
> need to be updated.

> Specifically, your recent upload of 'package-name-0.0.1.tar.gz' is
> incompatible with PEP 625 because it does not contain the normalized
> project name 'package_name'.

> In most cases, this can be resolved by upgrading the version of your
> build tooling to a later version that supports PEP 625 and produces
> compliant filenames.